### PR TITLE
Add istanbul-reporter-raw-json to report raw json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "electron-prebuilt": "^1.0.0",
     "exit-code": "^1.0.2",
     "istanbul": "^0.4.3",
+    "istanbul-reporter-raw-json": "^1.0.1",
     "minimist": "^1.2.0",
     "multistream": "^2.0.5",
     "tap-finished": "0.0.1",

--- a/report-coverage.js
+++ b/report-coverage.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var istanbul = require('istanbul');
+var rawJsonReporter = require('istanbul-reporter-raw-json');
+istanbul.Report.register(rawJsonReporter);
 
 function report(objects, reports) {
   var collector = new istanbul.Collector();


### PR DESCRIPTION
When piping coverage test output to a TAP processor like `tap-spec`, and specifying `--report=text`, the text report portion might not get processed properly,  get mangled, or skipped altogether. 

For example:

```console
$ unitest --report=text --browser=browser-bundle.js --node=index.js | tap-nyan

 2   -__,------,
 0   -__|  /\_/\
 0   -_~|_( ^ .^)
     -_ ""  ""
  Pass!
```

Looks like nyan cat completely swallows the text report. The `tap-spec` de-colorizes the report decreasing visibility.

When using `istanbul` directly, we can use `istanbul report` command to print out the report after the initial coverage has been recorded, but this report will not match the one produced by unitest.

The solution is to give unitest an ability to export `coverage.raw.json`, via `--report=raw-json`, to mimic istanbul 1.0 alpha default raw coverage output.

Then we can use `istanbul report text --include coverage/coverage.raw.json` to quickly write the report using the raw coverage results stored in `coverage/coverage.raw.json` as the source of truth.

This allows us to decouple the build and report scripts, while preserving speed and maintaining proper output along the way:

![cov mov](https://cloud.githubusercontent.com/assets/1486609/15203330/61fbb4d2-17b7-11e6-8691-ac379fc1b3d8.gif)



