### PR TITLE
Bump electron-prebuilt to 1.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "backoff": "^2.5.0",
-    "electron-prebuilt": "^1.0.0",
+    "electron-prebuilt": "^1.4.13",
     "exit-code": "^1.0.2",
     "getport": "^0.1.0",
     "istanbul": "^0.4.3",


### PR DESCRIPTION
As explained in #18, with the older version of electron (1.0.0) the following errors were popping up:

```sh
    [14:53:32] Starting 'run:test'...
    [warn] kq_init: detected broken kqueue; not using.: Undefined error: 0
    [warn] kq_init: detected broken kqueue; not using.: Undefined error: 0
    [warn] kq_init: detected broken kqueue; not using.: Undefined error: 0
    [warn] kq_init: detected broken kqueue; not using.: Undefined error: 0
```

I tried upgrading electron-prebuilt
```sh
> cd node_modules/unitest && npm install --save electron-prebuilt
```

Things are now in working order
```sh
[15:09:31] Finished 'build:test-client' after 8.29 s
    > [redacted]@0.0.1 fast-test /Users/dschnurr/[redacted]
    > NODE_ENV=test gulp run:test --gulpfile gulpfile-dev.js
    [15:09:34] Using gulpfile [redacted]
    [15:09:34] Starting 'run:test'...

  Browser test passes

    ✔ Browser test passes
    [15:09:35] Finished 'run:test' after 1.9 s


  total:     1
  passing:   1
  duration:  3.2s
```