### PR TITLE
Hard pin merge2 to version 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "exit-code": "^1.0.2",
     "getport": "^0.1.0",
     "istanbul-lib-coverage": "^1.0.1",
-    "merge2": "^1.0.2",
+    "merge2": "1.0.3",
     "minimist": "^1.2.0",
     "multistream": "^2.0.5",
     "run-parallel": "^1.1.6",


### PR DESCRIPTION
In version 1.1.0 of this package, the developers started using ES2015
features that are not supported in 0.10, causing a semver violation. I
will follow up with them but it's helpful for now to pin this
dependency.