### PR TITLE
Pin electron version so yarn can find it in travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "backoff": "^2.5.0",
-    "electron": "^1.4.13",
+    "electron": "~1.4.13",
     "exit-code": "^1.0.2",
     "getport": "^0.1.0",
     "istanbul-lib-coverage": "^1.0.1",


### PR DESCRIPTION
When running `yarn install` in Travis in a project that uses unitest, you get the error: `An unexpected error occurred: "https://registry.yarnpkg.com/electron/-/electron-1.8.0.tgz: Request failed \"404 Not Found\""`.

This change ensures yarn installs electron 1.4.13, which does exist in their registry