### PR TITLE
Ensure non-zero status codes and logs for unhandled promise rejections

### DIFF
--- a/fixtures/unhandled-rejection.js
+++ b/fixtures/unhandled-rejection.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var test = require('tape');
+
+test('a test with an unhandled rejection', async t => {
+  t.pass('a passing assertion');
+  await throws();
+  t.end();
+});
+
+async function throws() {
+  // return Promise.reject({some: 'rejection'});
+  throw new Error('an async error');
+}
+
+/**
+ * Mock coverage object
+ */
+global.__coverage__ = {};

--- a/lib/ipc-helpers/dump-node.js
+++ b/lib/ipc-helpers/dump-node.js
@@ -2,6 +2,18 @@
 
 let didSend = false;
 
+process.on('unhandledRejection', reason => {
+  if (reason.stack) {
+    console.error(reason.stack);
+  } else {
+    console.error('Unhandled promise rejection with reason:', reason);
+    console.error(
+      `Note: use async functions instead of promises for stack traces.`
+    );
+  }
+  process.exit(1);
+});
+
 // process.send takes a callback on Node 4+ and should be called in beforeExit
 // process.send will schedule more work, so we check to only send once
 process.on('beforeExit', function sendCovereageOnBeforeExit() {

--- a/lib/run-chrome.js
+++ b/lib/run-chrome.js
@@ -39,8 +39,7 @@ async function runChrome(entry, cb) {
     const {Page, Runtime} = client;
 
     Runtime.exceptionThrown(e => {
-      let {description} = e.exceptionDetails.exception;
-      const str = description + '\n';
+      const str = getExceptionMessage(e.exceptionDetails) + '\n';
       donestream.write(str);
       outstream.write(str);
       exitCode = 1;
@@ -112,4 +111,27 @@ function startServer(entry) {
       </html>
     `);
   });
+}
+
+function getExceptionMessage(exceptionDetails) {
+  if (
+    exceptionDetails.exception &&
+    exceptionDetails.exception.subtype === 'error'
+  ) {
+    return exceptionDetails.exception.description;
+  }
+  let message = exceptionDetails.text;
+  if (exceptionDetails.stackTrace) {
+    for (const callframe of exceptionDetails.stackTrace.callFrames) {
+      const location =
+        callframe.url +
+        ':' +
+        callframe.lineNumber +
+        ':' +
+        callframe.columnNumber;
+      const functionName = callframe.functionName || '<anonymous>';
+      message += `\n    at ${functionName} (${location})`;
+    }
+  }
+  return message;
 }

--- a/lib/run-node.js
+++ b/lib/run-node.js
@@ -9,7 +9,9 @@ const DUMP_NODE_PATH = path.join(__dirname, './ipc-helpers/dump-node.js');
 function runNode(entry, cb) {
   let coverage = {};
   let exitCode = 0;
-  const child = spawn('node', [], {stdio: [null, null, null, 'ipc']});
+  const child = spawn('node', [], {
+    stdio: [null, null, null, 'ipc'],
+  });
   child.on('message', message => {
     coverage = message.coverage;
   });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "fixtures": "babel --plugins=istanbul fixtures/uninstrumented -d fixtures/instrumented && globify 'fixtures/*.js' --outfile=fixtures/browser",
     "pretest": "rm -rf .nyc_output/* && npm run fixtures",
-    "test": "npm run lint && node test/index.js"
+    "just-test": "node test/index.js",
+    "test": "npm run lint && npm run just-test"
   },
   "dependencies": {
     "chrome-launcher": "^0.9.0",

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,10 @@ const passingEntry = path.resolve(__dirname, '../fixtures/passing.js');
 const failingEntry = path.resolve(__dirname, '../fixtures/failing.js');
 const mockEntry = path.resolve(__dirname, '../fixtures/mock-entry.js');
 const errorEntry = path.resolve(__dirname, '../fixtures/error.js');
+const unhandledEntry = path.resolve(
+  __dirname,
+  '../fixtures/unhandled-rejection.js'
+);
 const exit123Entry = path.resolve(__dirname, '../fixtures/exit-123.js');
 const slowPassingEntry = path.resolve(__dirname, '../fixtures/slow-passing.js');
 
@@ -38,6 +42,10 @@ const mockEntryBrowser = path.resolve(
 const errorEntryBrowser = path.resolve(
   __dirname,
   '../fixtures/browser/error.js'
+);
+const unhandledEntryBrowser = path.resolve(
+  __dirname,
+  '../fixtures/browser/unhandled-rejection.js'
 );
 const exit123EntryBrowser = path.resolve(
   __dirname,
@@ -234,6 +242,34 @@ test('both error status code', t => {
   ]);
   child.on('close', code => {
     t.ok(code);
+  });
+});
+
+test('node unhandled rejection status code', t => {
+  t.plan(1);
+  const child = spawn('node', [
+    cliPath,
+    '--node',
+    unhandledEntry,
+    '--browser',
+    passingEntryBrowser,
+  ]);
+  child.on('close', code => {
+    t.ok(code, 'exits with a non-zero status code');
+  });
+});
+
+test('browser unhandled rejection status code', t => {
+  t.plan(1);
+  const child = spawn('node', [
+    cliPath,
+    '--node',
+    passingEntry,
+    '--browser',
+    unhandledEntryBrowser,
+  ]);
+  child.on('close', code => {
+    t.ok(code, 'exits with a non-zero status code');
   });
 });
 


### PR DESCRIPTION
Unhandled promise rejections should be logged and cause tests to immediately exit with a non-zero status code.